### PR TITLE
Change "is" to "as"

### DIFF
--- a/blockchain-101/lesson-blockchain-3.md
+++ b/blockchain-101/lesson-blockchain-3.md
@@ -3,7 +3,7 @@
 At its core the blockchain records and keeps track of transactions in a digital ledger (think of it as a massive database of everyone sending and receiving money(cryptocurrencies) and other digital assets (NFTs, Smart Contracts).
 Now here’s where the Block comes in: Blockchain. 
 
-A Blockchain will store these transactions in groups of blocks. Each record of the transaction will have an address(their wallet Public Key) of the person sending the transaction, the person receiving the transaction, the amount being sent, the timestamp, and a unique Hash. A genesis is the first block that is created in a blockchain network, think of it is an epoch.
+A Blockchain will store these transactions in groups of blocks. Each record of the transaction will have an address(their wallet Public Key) of the person sending the transaction, the person receiving the transaction, the amount being sent, the timestamp, and a unique Hash. A genesis is the first block that is created in a blockchain network, think of it as an epoch.
 
 ![https://cadena.incl.us/wp-content/uploads/2021/12/block-3.png](https://cadena.incl.us/wp-content/uploads/2021/12/block-3.png)
 *Credit: RubyGarage*


### PR DESCRIPTION
There was a typo or a grammar mistake.